### PR TITLE
Add command-line tool for watermarking and numbering PDFs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+build/
+dist/
+*.egg-info/
+.pytest_cache/
+.eggs/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,62 @@
-# Logbook-Maker
+# Logbook Maker
+
+PDF 문서에 페이지 번호와 사본관리 워터마크(Controlled Copy)를 손쉽게 추가할 수 있는 커맨드라인 도구입니다. 입력한 사본관리 번호가 각 페이지 상단에 표시되고, 페이지 하단에는 지정한 총 페이지 수에 맞춰 페이지 번호가 부여됩니다.
+
+## 주요 기능
+
+- 전체 혹은 지정한 페이지 수만큼 페이지 번호 부여
+- 각 페이지마다 "Controlled Copy" 워터마크 추가
+- 사본관리 번호(Copy No) 텍스트를 사용자 입력으로 표시
+- 페이지/복사본 라벨 문구 커스터마이즈 가능
+
+## 설치 방법
+
+```bash
+python -m pip install --upgrade pip
+python -m pip install .[dev]
+```
+
+> 개발 환경이 아닌 경우에는 `.[dev]` 대신 `.` 만 설치하면 됩니다.
+
+## 사용법
+
+기본 사용 예시는 다음과 같습니다.
+
+```bash
+logbook-maker input.pdf output.pdf --copy-number "CC-2024-001"
+```
+
+### 자주 사용하는 옵션
+
+- `--max-pages`: 처음부터 지정한 수만큼의 페이지만 워터마크 및 페이지 번호를 부여합니다. 나머지 페이지는 원본 그대로 복사됩니다.
+- `--total-pages`: 페이지 번호에 표시될 전체 페이지 수를 직접 지정할 수 있습니다.
+- `--start-number`: 시작 페이지 번호를 변경할 수 있습니다.
+- `--watermark-text`: 워터마크 문구를 바꿀 수 있습니다.
+- `--copy-label-template`: 사본관리 번호 라벨 포맷을 지정합니다. 예) `"사본번호: {copy_number}"`
+- `--page-label-template`: 페이지 번호 라벨 포맷을 지정합니다. 예) `"{number} / {total} 페이지"`
+
+### 파이썬 모듈에서 사용하기
+
+```python
+from logbook_maker import annotate_pdf
+
+annotate_pdf(
+    "input.pdf",
+    "output.pdf",
+    copy_number="CC-2024-001",
+    total_pages=10,
+)
+```
+
+## 개발 및 테스트
+
+테스트 실행:
+
+```bash
+python -m pytest
+```
+
+## 주의 사항
+
+- 워터마크 및 텍스트는 기본적으로 회색으로 적용되며, PDF 뷰어에 따라 투명도가 다르게 보일 수 있습니다.
+- 입력 PDF는 암호화되어 있지 않아야 하며, 읽기 권한이 필요합니다.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "logbook-maker"
+version = "0.1.0"
+description = "Annotate PDF logbooks with page numbers and Controlled Copy watermarks."
+readme = "README.md"
+authors = [{ name = "Logbook Maker" }]
+requires-python = ">=3.9"
+dependencies = [
+    "pypdf>=3.8",
+    "reportlab>=4.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+]
+
+[project.scripts]
+logbook-maker = "logbook_maker.processor:main"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/logbook_maker/__init__.py
+++ b/src/logbook_maker/__init__.py
@@ -1,0 +1,7 @@
+"""Utilities for annotating logbook PDFs with watermarks and numbering."""
+
+from .processor import annotate_pdf
+
+__all__ = ["annotate_pdf"]
+
+__version__ = "0.1.0"

--- a/src/logbook_maker/__main__.py
+++ b/src/logbook_maker/__main__.py
@@ -1,0 +1,7 @@
+"""Command-line entry point for Logbook Maker."""
+
+from .processor import main
+
+
+if __name__ == "__main__":
+    main()

--- a/src/logbook_maker/processor.py
+++ b/src/logbook_maker/processor.py
@@ -1,0 +1,214 @@
+"""Core functionality for applying watermarks and page numbers to PDFs."""
+
+from __future__ import annotations
+
+import argparse
+import io
+from pathlib import Path
+from typing import Optional
+
+from pypdf import PdfReader, PdfWriter
+from reportlab.lib import colors
+from reportlab.lib.units import inch
+from reportlab.pdfgen import canvas
+
+
+def annotate_pdf(
+    input_pdf: Path | str,
+    output_pdf: Path | str,
+    *,
+    copy_number: str,
+    watermark_text: str = "Controlled Copy",
+    copy_label_template: str = "Copy No: {copy_number}",
+    page_label_template: str = "Page {number} / {total}",
+    start_number: int = 1,
+    total_pages: Optional[int] = None,
+    max_pages: Optional[int] = None,
+) -> None:
+    """Apply numbering and a watermark to a PDF file.
+
+    Parameters
+    ----------
+    input_pdf:
+        Path to the source PDF.
+    output_pdf:
+        Path where the annotated PDF will be saved.
+    copy_number:
+        Identifier printed at the top of each page.
+    watermark_text:
+        Text placed diagonally across each processed page.
+    copy_label_template:
+        Template string for rendering the copy number.
+    page_label_template:
+        Template string for rendering the page number.
+    start_number:
+        Page number used for the first processed page.
+    total_pages:
+        Total number of pages displayed in the page label. Defaults to the
+        amount of processed pages added to ``start_number`` minus one.
+    max_pages:
+        Limit of pages to process. Remaining pages are copied without
+        annotations.
+    """
+
+    input_path = Path(input_pdf)
+    output_path = Path(output_pdf)
+
+    if not input_path.exists():
+        raise FileNotFoundError(f"Input PDF does not exist: {input_path}")
+
+    if start_number < 1:
+        raise ValueError("start_number must be at least 1")
+
+    reader = PdfReader(str(input_path))
+    writer = PdfWriter()
+
+    total_page_count = len(reader.pages)
+
+    if max_pages is not None:
+        if max_pages < 1:
+            raise ValueError("max_pages must be a positive integer")
+        processed_page_count = min(max_pages, total_page_count)
+    else:
+        processed_page_count = total_page_count
+
+    calculated_total = start_number + processed_page_count - 1
+    if total_pages is None:
+        total_pages = calculated_total
+    elif total_pages < calculated_total:
+        raise ValueError(
+            "total_pages is smaller than the number of pages that will be "
+            "numbered."
+        )
+
+    for index, page in enumerate(reader.pages):
+        if index < processed_page_count:
+            current_number = start_number + index
+            page_label = page_label_template.format(
+                number=current_number, total=total_pages
+            )
+            copy_label = copy_label_template.format(copy_number=copy_number)
+            overlay = _build_overlay_page(
+                page.mediabox.width,
+                page.mediabox.height,
+                page_label,
+                copy_label,
+                watermark_text,
+            )
+            page.merge_page(overlay)
+        writer.add_page(page)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("wb") as file_out:
+        writer.write(file_out)
+
+
+def _build_overlay_page(
+    width: float,
+    height: float,
+    page_label: str,
+    copy_label: str,
+    watermark_text: str,
+):
+    """Create an overlay PDF page with the provided labels."""
+
+    packet = io.BytesIO()
+    c = canvas.Canvas(packet, pagesize=(float(width), float(height)))
+
+    margin = 0.6 * inch
+
+    # Copy number at the top-right corner.
+    c.setFont("Helvetica-Bold", 14)
+    c.setFillColor(colors.black)
+    c.drawRightString(float(width) - margin, float(height) - margin, copy_label)
+
+    # Page number at the bottom centre.
+    c.setFont("Helvetica", 12)
+    c.drawCentredString(float(width) / 2.0, margin / 2.0, page_label)
+
+    # Watermark diagonally across the page.
+    c.saveState()
+    c.setFillColor(colors.Color(0.7, 0.7, 0.7, alpha=0.2))
+    c.setFont("Helvetica-Bold", min(float(width), float(height)) * 0.1)
+    c.translate(float(width) / 2.0, float(height) / 2.0)
+    c.rotate(45)
+    c.drawCentredString(0, 0, watermark_text)
+    c.restoreState()
+
+    c.save()
+    packet.seek(0)
+    overlay_reader = PdfReader(packet)
+    return overlay_reader.pages[0]
+
+
+def build_argument_parser() -> argparse.ArgumentParser:
+    """Return an argument parser configured for the CLI."""
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Add page numbers and a Controlled Copy watermark to a PDF file."
+        )
+    )
+    parser.add_argument("input_pdf", type=Path, help="Path to the source PDF")
+    parser.add_argument(
+        "output_pdf", type=Path, help="Where the annotated PDF will be saved"
+    )
+    parser.add_argument(
+        "--copy-number",
+        required=True,
+        help="Identifier displayed on every page",
+    )
+    parser.add_argument(
+        "--watermark-text",
+        default="Controlled Copy",
+        help="Text used as a diagonal watermark",
+    )
+    parser.add_argument(
+        "--copy-label-template",
+        default="Copy No: {copy_number}",
+        help="Template for the copy number label",
+    )
+    parser.add_argument(
+        "--page-label-template",
+        default="Page {number} / {total}",
+        help="Template for the page numbering label",
+    )
+    parser.add_argument(
+        "--start-number",
+        type=int,
+        default=1,
+        help="Number used for the first processed page",
+    )
+    parser.add_argument(
+        "--total-pages",
+        type=int,
+        help="Explicit total used in the page label",
+    )
+    parser.add_argument(
+        "--max-pages",
+        type=int,
+        help="Limit how many pages from the start of the PDF are processed",
+    )
+    return parser
+
+
+def main(args: Optional[list[str]] = None) -> None:
+    """Entry point for the command-line interface."""
+
+    parser = build_argument_parser()
+    parsed = parser.parse_args(args=args)
+    annotate_pdf(
+        parsed.input_pdf,
+        parsed.output_pdf,
+        copy_number=parsed.copy_number,
+        watermark_text=parsed.watermark_text,
+        copy_label_template=parsed.copy_label_template,
+        page_label_template=parsed.page_label_template,
+        start_number=parsed.start_number,
+        total_pages=parsed.total_pages,
+        max_pages=parsed.max_pages,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pypdf import PdfReader
+
+from logbook_maker.processor import annotate_pdf
+
+
+def _create_sample_pdf(path: Path, page_count: int = 3) -> None:
+    from reportlab.lib.pagesizes import A4
+    from reportlab.pdfgen import canvas
+
+    c = canvas.Canvas(str(path), pagesize=A4)
+    for page in range(page_count):
+        c.setFont("Helvetica", 14)
+        c.drawString(72, 800, f"Original content on page {page + 1}")
+        c.showPage()
+    c.save()
+
+
+@pytest.mark.parametrize("page_count", [1, 3])
+def test_annotate_pdf_creates_watermarked_output(tmp_path: Path, page_count: int) -> None:
+    input_pdf = tmp_path / "input.pdf"
+    output_pdf = tmp_path / "output.pdf"
+    _create_sample_pdf(input_pdf, page_count)
+
+    annotate_pdf(
+        input_pdf,
+        output_pdf,
+        copy_number="CC-001",
+    )
+
+    assert output_pdf.exists()
+
+    reader = PdfReader(str(output_pdf))
+    assert len(reader.pages) == page_count
+
+    for index, page in enumerate(reader.pages):
+        text = page.extract_text() or ""
+        assert "Controlled Copy" in text
+        assert "Copy No: CC-001" in text
+        assert f"Page {index + 1} / {page_count}" in text
+
+
+def test_max_pages_limits_processing(tmp_path: Path) -> None:
+    input_pdf = tmp_path / "input.pdf"
+    output_pdf = tmp_path / "output.pdf"
+    _create_sample_pdf(input_pdf, page_count=4)
+
+    annotate_pdf(
+        input_pdf,
+        output_pdf,
+        copy_number="CC-002",
+        max_pages=2,
+        total_pages=5,
+    )
+
+    reader = PdfReader(str(output_pdf))
+    assert len(reader.pages) == 4
+
+    first_page_text = reader.pages[0].extract_text() or ""
+    third_page_text = reader.pages[2].extract_text() or ""
+
+    assert "Page 1 / 5" in first_page_text
+    assert "Copy No: CC-002" in first_page_text
+
+    # Pages beyond the max_pages limit should not have new annotations.
+    assert "Copy No: CC-002" not in third_page_text
+    assert "Page 3 / 5" not in third_page_text


### PR DESCRIPTION
## Summary
- add a command-line interface for applying Controlled Copy watermarks and page numbers to PDFs
- implement reusable annotation logic and expose it as a Python API
- document installation/usage details and add automated tests for the processor

## Testing
- python -m pytest *(fails in the execution environment: ModuleNotFoundError: No module named 'pypdf' because dependencies cannot be installed without internet access)*

------
https://chatgpt.com/codex/tasks/task_e_68cb58a9ae98832dadf2b57622a6901d